### PR TITLE
API rehaul and documentation

### DIFF
--- a/bones/bot.py
+++ b/bones/bot.py
@@ -344,6 +344,7 @@ class BonesBot(irc.IRCClient):
 
     def action(self, user, channelName, data):
         channel = self.get_channel(channelName)
+        user = self.get_user(user)
         log.debug(
             "User %s actioned in %s: %s",
             user, channel, data
@@ -362,11 +363,10 @@ class BonesBot(irc.IRCClient):
 
     def topicUpdated(self, hostmask, channelName, newTopic):
         channel = self.get_channel(channelName)
-        # TODO: Use self.users and utility methods
-        user = bones.event.User(hostmask, self)
+        user = self.get_user(hostmask)
         log.debug(
             "User %s changed topic of %s to %s",
-            user.nickname, channel, newTopic
+            user, channel, newTopic
         )
         channel.topic = bones.event.Topic(newTopic, user)
         event = bones.event.ChannelTopicChangedEvent(

--- a/bones/event.py
+++ b/bones/event.py
@@ -1016,8 +1016,8 @@ class UserActionEvent(Event):
 
     :param client: The bot instance where this event occured.
     :type client: :class:`bones.bot.BonesBot`
-    :param user: The hostmask of the user which initiated this event.
-    :type user: str.
+    :param user: The user that initiated this event.
+    :type user: :class:`bones.event.User`
     :param channel: The channel the :code:`CTCP ACTION` was sent to.
     :type channel: str.
     :param data: The text which is actioned.
@@ -1051,7 +1051,7 @@ class UserActionEvent(Event):
     """
     def __init__(self, client, user, channel, data):
         self.client = client
-        self.user = User(user, client)
+        self.user = user
         self.channel = channel
         self.data = data
 

--- a/bones/modules/utilities.py
+++ b/bones/modules/utilities.py
@@ -93,6 +93,18 @@ class Utilities(Module):
                         .find("div", {"class": "permalink-inner permalink-tweet-container"}) \
                         .find("span", {"class": "username js-action-profile-name"}) \
                         .text
+
+                    # shitty fix for pic.twitter.com links
+                    # could be improved by going through all links, check
+                    # whether they start with http and if not replace the
+                    # nodeText with the href attribute.
+                    out = []
+                    for word in tweet.split(" "):
+                        if word.startswith("pic.twitter.com"):
+                            word = "https://%s" % word
+                        out.append(word)
+                    tweet = " ".join(out)
+
                     msg = (u"\x0310Twitter\x03 \x0311::\x03 %s \x0311––\x03 %s"
                            % (tweet, user))
                     event.channel.msg(msg.encode("utf-8"))


### PR DESCRIPTION
This is a WIP proposal/goal/spec. for the planned API rehaul. There is no promises that this will look like the final product.
## Event API
**Use classes instead of strings**
~~~~python
## Now:
@bones.event.handler(event="UserJoinEvent")

bones.event.fire("servertag", "UserJoinEvent", event)
bones.event.fire("servertag", "UserQuitEvent", event)
bones.event.fire("servertag", "irc_unknown", prefix, command, args)

## Goal:
@bones.event.handler(event=bones.event.UserJoinEvent)
bones.event.fire("servertag", event)  # new syntax
bones.event.fire("servertag", "UserQuit", event)  # old syntax, still working
bones.event.fire("servertag", "irc_unknown", prefix, command, args)  # even older syntax, still working
~~~~

### Status
- [x] Class-style event handlers
- [x] Class-style event firing

## User and Channel API
**Goal 1: Reduce the amount of code needed for modules.**
Examples, now:
~~~~python
## Ex. 1
event.client.msg(event.channel, "Message")

## Ex. 2
event.client.kick(event.channel, event.user.nickname, "Reason")

## Ex. 3
event.client.leave(event.channel, reason="Reason")

## Ex. 4
# It is currently not possible to track users in a channel

## Ex. 5
# It is currently not possible to check for modes

## Ex. 6
event.client.notice(event.user.nickname, "Notice")
~~~~
What we want:
~~~~python
## Ex. 1
event.channel.msg("Message")

## Ex. 2
event.channel.kick(event.user, "Reason")

## Ex. 3
event.channel.part("Reason")

## Ex. 4
len(event.channel.users)
for user in event.channel.users:
    user.notice("Ahuehue")

## Ex. 5
if "m" in event.channel.modes: pass

## Ex. 6
event.user.notice("Notice")
~~~~

### Status
**Channel Utility Class**
- [x] Kick Method
- [x] Message Method
- ~~Mode Management~~ (This should be implemented as we override irc_MODE #52)
- [x] Notice Method
- [x] User list
- [x] Part method

**User Utility Class**
- [x] Channel list
- [x] Kick Method
- [x] Message Method
- [x] Notice Method
- Tracking implementation
    - [x] Nick changes
    - Instantiation/removal on:
        - [x] Topic change
        - [x] User join
        - [x] User quit
        - [x] User part
        - [x] User message
        - ~~Mode changes~~ (This should be implemented as we override irc_MODE #52)
        - ~~User notice~~ (This should be implemented as a part of ServerNoticeEvents #43)
    - Support in events
        - All points mentioned above plus:
        - [x] User action
    - Other details
        - [x] **Update hostname/username when changed** *Implemented in `get_user`, gets done if the query field contains a hostmask*

## Merge-time checklist
- [ ] Update `bones.modules.funserv.QDB` and other `urllib`-based modules to use `self.factory`, rather than grabbing the factory from an event.
- [ ] Update `BonesBot.quit()` to use new-style (Event instance based) events.