### PR TITLE
Make use of sets for channel list modes

### DIFF
--- a/bones/bot.py
+++ b/bones/bot.py
@@ -245,16 +245,8 @@ class BonesBot(irc.IRCClient):
 
     def modeChanged(self, user, target, set, modes, args):
         # TODO: Ditch this and override irc_MODE
-        if set:
-            setString = "+"
-        else:
-            setString = "-"
         # TODO: This should be changed as a part of the interface for mode
         # changing we'll make at one point in time.
-        log.info(
-            "Mode change in %s: %s set %s%s (%s)",
-            target, user, setString, modes, args
-        )
         if [True for x in self.channel_types if x is target[0]]:
             target = self.get_channel(target)
             args = [x for x in args if x is not None]

--- a/bones/event.py
+++ b/bones/event.py
@@ -316,11 +316,11 @@ class Channel(Target):
             arg = args.pop(0)
             if mode in self.modes and arg in self.modes[mode]:
                 log.debug("Removing element '%s' from modelist '%s' in %s",
-                          args[0], mode, self)
+                          arg, mode, self)
                 self.modes[mode].remove(arg)
             else:
                 log.debug("Ignoring modelist '%s' removal of '%s' in %s",
-                          mode, args[0], self)
+                          mode, arg, self)
         elif mode in self.server.channel_modes["always"]:
             arg = args.pop(0)
             if mode in self.modes and arg:

--- a/bones/event.py
+++ b/bones/event.py
@@ -293,13 +293,21 @@ class Channel(Target):
         if mode in self.server.channel_modes["list"] or \
                 [True for m, p in self.server.prefixes if m == mode]:
             if mode not in self.modes:
+                log.debug("Creating modelist '%s' for %s", mode, self)
                 self.modes[mode] = set()
+            log.debug("Adding element '%s' to modelist '%s' in %s", args[0],
+                      mode, self)
             self.modes[mode].add(args.pop(0))
         elif mode in self.server.channel_modes["always"]:
+            log.debug("Setting value-mode '%s' with argument '%s' in %s", mode,
+                      args[0], self)
             self.modes[mode] = args.pop(0)
         elif mode in self.server.channel_modes["set"]:
+            log.debug("Setting option-mode '%s' with argument '%s' in %s",
+                      mode, args[0], self)
             self.modes[mode] = args.pop(0)
         else:
+            log.debug("Setting boolean mode '%s' in %s", mode, self)
             self.modes[mode] = True
 
     def _unset_mode(self, mode, args):
@@ -307,17 +315,35 @@ class Channel(Target):
                 [True for m, p in self.server.prefixes if m == mode]:
             arg = args.pop(0)
             if mode in self.modes and arg in self.modes[mode]:
+                log.debug("Removing element '%s' from modelist '%s' in %s",
+                          args[0], mode, self)
                 self.modes[mode].remove(arg)
+            else:
+                log.debug("Ignoring modelist '%s' removal of '%s' in %s",
+                          mode, args[0], self)
         elif mode in self.server.channel_modes["always"]:
             arg = args.pop(0)
             if mode in self.modes and arg:
+                log.debug("Removing value-mode '%s' ('%s') from channel %s",
+                          mode, arg, self)
                 del self.modes[mode]
+            else:
+                log.debug("Ignoring value-mode removal of '%s' ('%s') in %s",
+                          mode, arg, self)
         elif mode in self.server.channel_modes["set"]:
             if mode in self.modes:
+                log.debug("Removing option-mode '%s' from %s", mode, self)
                 del self.modes[mode]
+            else:
+                log.debug("Ignoring option-mode removal of '%s' from %s", mode,
+                          self)
         else:
             if mode in self.modes:
+                log.debug("Removing boolean mode '%s' from %s", mode, self)
                 del self.modes[mode]
+            else:
+                log.debug("Removing boolean mode removal of '%s' from %s",
+                          mode, self)
 
     def kick(self, user, reason=None):
         """

--- a/bones/event.py
+++ b/bones/event.py
@@ -293,8 +293,8 @@ class Channel(Target):
         if mode in self.server.channel_modes["list"] or \
                 [True for m, p in self.server.prefixes if m == mode]:
             if mode not in self.modes:
-                self.modes[mode] = []
-            self.modes[mode].append(args.pop(0))
+                self.modes[mode] = set()
+            self.modes[mode].add(args.pop(0))
         elif mode in self.server.channel_modes["always"]:
             self.modes[mode] = args.pop(0)
         elif mode in self.server.channel_modes["set"]:


### PR DESCRIPTION
This PR also changes logging of mode changes to reflect how we want debug vs. raw logging to work.

Raw logging should be used to reflect the traffic we see (as in what happens) while debug logging should reflect the actions the bot takes while handling events. On that note info logging should reflect things that happens and are worth noting and isn't really an error in any way. Warnings should be used for errors that can be/was handled gracefully, and error logging and exceptions for unhandled errors.